### PR TITLE
Add Console visualization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ No project,HeyYouAreAwesome.xcworkspace,1597876725,1597876729,Build Succeeded,4
 ```
 
 # Visualization
+
+## Console
+Run `ruby ~/.timecheck/report_time.rb`
+
+This script will output the accumulated time you've spend building projects on Xcode within the current day, separated by project.
+It will keep reporting updated times as soon as a build/run is finished.
+To stop it, just use `Ctrl+C`
+
+<img width="702" alt="Screen Shot 2020-10-07 at 1 41 22 PM" src="https://user-images.githubusercontent.com/7887319/95315175-36fa5900-08a3-11eb-87cd-f48e5cf36f14.png">
+
+## Graphically
 The next step is to visualize this information.
 I used [R](https://www.r-project.org/about.html) language for that. But there's more coming
 This how it can look like if you'll be able to setup R correcly :)

--- a/scripts/report_time.rb
+++ b/scripts/report_time.rb
@@ -1,0 +1,68 @@
+# This script will output the accumulated time you've spend building projects on Xcode within the current day.
+#
+# Output looks like:
+#    *********
+#    You've spent 27min 24s building <your-project-name>.xcworkspace today
+#
+#
+# To use it:
+# 1. Follow the installation process from https://github.com/PaulTaykalo/xcode-time-tracker
+# 2. Copy this script to `~/.timecheck` folder.
+# 3. Run `ruby ~/.timecheck/report_time.rb`
+#
+# This is a never ending script that will keep reporting updated times as soon as a build/run is finished.
+# To stop it, just use Ctrl+C
+
+require 'Listen'
+require 'Date'
+
+path = "#{Dir.home}/.timecheck"
+
+def report_time(path)
+	data = File.read("#{path}/results")
+	rows = data.split("\n")
+
+	projects = {}
+
+	for i in 0...rows.count
+		values = rows[i].split(",")
+		project = (values[0].include? "xcodeproj") ? values[0] : nil 
+		workspace = (values[1].include? "xcworkspace") ? values[1] : nil
+		start = values[3]
+		event = values[4]
+		duration = values[5]
+
+		object = {
+			"event": event,
+			"start": start,
+			"duration": duration
+		}
+
+		project_name = project ||= workspace
+		projects[project_name] = (projects[project_name] ||= []).append(object)
+	end
+
+	puts "*********"
+	projects.each do |project, events|
+		time_spent_on_build = 0
+		for i in 0...events.count
+			event = events[i]
+			date = Date.strptime(event[:start].to_s, '%s')
+			if date == Date.today
+				time_spent_on_build += event[:duration].to_i
+			end
+		end
+	seconds = time_spent_on_build % 60
+	minutes = time_spent_on_build / 60
+
+	puts "You've spent #{minutes}min #{seconds}s building #{project} today"
+	end
+end
+
+report_time(path)
+
+listener = Listen.to(path) { |modified, added, removed|
+	report_time(path)
+}
+listener.start
+sleep

--- a/scripts/report_time.rb
+++ b/scripts/report_time.rb
@@ -1,15 +1,5 @@
 # This script will output the accumulated time you've spend building projects on Xcode within the current day.
 #
-# Output looks like:
-#    *********
-#    You've spent 27min 24s building <your-project-name>.xcworkspace today
-#
-#
-# To use it:
-# 1. Follow the installation process from https://github.com/PaulTaykalo/xcode-time-tracker
-# 2. Copy this script to `~/.timecheck` folder.
-# 3. Run `ruby ~/.timecheck/report_time.rb`
-#
 # This is a never ending script that will keep reporting updated times as soon as a build/run is finished.
 # To stop it, just use Ctrl+C
 

--- a/visualization/ruby/report_time.rb
+++ b/visualization/ruby/report_time.rb
@@ -42,10 +42,13 @@ def report_time(path)
 				time_spent_on_build += event[:duration].to_i
 			end
 		end
-	seconds = time_spent_on_build % 60
-	minutes = time_spent_on_build / 60
+		seconds = time_spent_on_build % 60
+		minutes = time_spent_on_build / 60
 
-	puts "You've spent #{minutes}min #{seconds}s building #{project} today"
+		if seconds == 0 && minutes == 0
+			next
+		end
+		puts "You've spent #{minutes}min #{seconds}s building #{project} today"
 	end
 end
 


### PR DESCRIPTION
This PR adds a ruby script that will continuously output updated results for build times for the current day.

It looks like:
<img width="702" alt="Screen Shot 2020-10-07 at 1 41 22 PM" src="https://user-images.githubusercontent.com/7887319/95315175-36fa5900-08a3-11eb-87cd-f48e5cf36f14.png">

While the R approach is nice, I thought a live feedback on the time I was spending building my projects was providing me more direct insights.

Happy to do changes if there's anything you feel it's not correct 😄 

(Mistakenly closed #4 🙏 )